### PR TITLE
Fix overloads for the return method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ export class MaybeInstance<TIn> {
         }
     }
 
-    public return(defaultValue?: TIn): TIn;
+    public return<TOut>(): TOut | undefined;
+    public return(defaultValue: TIn): TIn;
     public return<TOut>(accessor: (p: TIn) => TOut): TOut | undefined;
     public return<TOut>(accessor: (p: TIn) => TOut | undefined, defaultValue: TOut): TOut;
 


### PR DESCRIPTION
Since the return method's accessor or (defaultValue) is optional, the return value might be undefined.
We can split the overloads into 2: 
1. Where if a defaultValue is specified the result has TIn type
2. Where if a defaultValue is not specified the result has the TOut or undefined type